### PR TITLE
Change processing on error

### DIFF
--- a/main.py
+++ b/main.py
@@ -78,7 +78,7 @@ def index():
             app.logger.warning("No image has been selected!")
             return jsonify({"code": 2, "message": "Warning: No image has been selected!"}), 400
         if not allowed_file(image.filename):
-            app.logger.warning("No image has been selected!")
+            app.logger.warning("Unauthorized extensions!")
             return jsonify({"code": 3, "message": "Warning: Unauthorized extensions!"}), 400
 
         img = np.frombuffer(image.read(), dtype=np.uint8)

--- a/main.py
+++ b/main.py
@@ -71,15 +71,15 @@ def index():
 
         if "image" not in request.files:
             app.logger.warning("Image parameter not POSTed!")
-            return jsonify({"code": 1, "message": "Warning: Image parameter not POSTed!"}), 400
+            return jsonify({"error_code": 1, "message": "Warning: Image parameter not POSTed!"}), 400
         image = request.files.get("image")
         app.logger.debug(f"Uploaded: {image}")
         if image.filename == "":
             app.logger.warning("No image has been selected!")
-            return jsonify({"code": 2, "message": "Warning: No image has been selected!"}), 400
+            return jsonify({"error_code": 2, "message": "Warning: No image has been selected!"}), 415
         if not allowed_file(image.filename):
             app.logger.warning("Unauthorized extensions!")
-            return jsonify({"code": 3, "message": "Warning: Unauthorized extensions!"}), 400
+            return jsonify({"error_code": 3, "message": "Warning: Unauthorized extensions!"}), 415
 
         img = np.frombuffer(image.read(), dtype=np.uint8)
         img = cv2.imdecode(img, 1)

--- a/main.py
+++ b/main.py
@@ -71,15 +71,12 @@ def index():
 
         if "image" not in request.files:
             app.logger.warning("Image parameter not POSTed!")
-            return jsonify({"error_code": 1, "message": "Warning: Image parameter not POSTed!"}), 400
+            return jsonify({"error_code": 40000, "message": "Warning: Image parameter not POSTed!"}), 400
         image = request.files.get("image")
         app.logger.debug(f"Uploaded: {image}")
-        if image.filename == "":
-            app.logger.warning("No image has been selected!")
-            return jsonify({"error_code": 2, "message": "Warning: No image has been selected!"}), 415
         if not allowed_file(image.filename):
             app.logger.warning("Unauthorized extensions!")
-            return jsonify({"error_code": 3, "message": "Warning: Unauthorized extensions!"}), 415
+            return jsonify({"error_code": 41500, "message": "Warning: Unauthorized extensions!"}), 415
 
         img = np.frombuffer(image.read(), dtype=np.uint8)
         img = cv2.imdecode(img, 1)

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import time
 import cv2
 import numpy as np
 import opencensus.trace.tracer
-from flask import Flask, flash, render_template, request, redirect, make_response, jsonify
+from flask import Flask, render_template, request, make_response, jsonify
 from flask_debugtoolbar import DebugToolbarExtension
 from opencensus.ext.stackdriver import trace_exporter as stackdriver_exporter
 
@@ -64,7 +64,8 @@ def allowed_file(filename):
 def index():
     if request.method == "GET":
         app.logger.debug("GET /index")
-        return render_template("index.html")
+        allowed_extensions = ",".join(["." + x for x in ALLOWED_EXTENSIONS])
+        return render_template("index.html", allowed_extensions=allowed_extensions)
     elif request.method == "POST":
         app.logger.debug("POST /index")
         start = time.time()

--- a/main.py
+++ b/main.py
@@ -77,7 +77,7 @@ def index():
         app.logger.debug(f"Uploaded: {image}")
         if image.filename == "":
             app.logger.warning("No image has been selected!")
-            return jsonify({"error_code": 41500, "message": "Warning: No image has been selected!"}), 415
+            return jsonify({"error_code": 41500, "message": "Warning: No image has been selected!"}), 428
         if not allowed_file(image.filename):
             app.logger.warning("Unauthorized extensions!")
             return jsonify({"error_code": 41501, "message": "Warning: Unauthorized extensions!"}), 415

--- a/main.py
+++ b/main.py
@@ -60,12 +60,6 @@ def allowed_file(filename):
     return "." in filename and filename.rsplit(".", 1)[1].lower() in ALLOWED_EXTENSIONS
 
 
-# def redirect_with_flash(url, message, category):
-#     app.logger.debug(message)
-#     flash(message, category)
-#     return redirect(url)
-
-
 @app.route("/", methods=["GET", "POST"])
 def index():
     if request.method == "GET":
@@ -76,17 +70,14 @@ def index():
         start = time.time()
 
         if "image" not in request.files:
-            # return redirect_with_flash(request.url, "Warning: Image parameter not POSTed!", "is-warning")
             app.logger.warning("Image parameter not POSTed!")
             return jsonify({"code": 1, "message": "Warning: Image parameter not POSTed!"}), 400
         image = request.files.get("image")
         app.logger.debug(f"Uploaded: {image}")
         if image.filename == "":
-            # return redirect_with_flash(request.url, "Warning: No image has been selected!", "is-warning")
             app.logger.warning("No image has been selected!")
             return jsonify({"code": 2, "message": "Warning: No image has been selected!"}), 400
         if not allowed_file(image.filename):
-            # return redirect_with_flash(request.url, "Warning: Unauthorized extensions!", "is-warning")
             app.logger.warning("No image has been selected!")
             return jsonify({"code": 3, "message": "Warning: Unauthorized extensions!"}), 400
 

--- a/main.py
+++ b/main.py
@@ -74,9 +74,12 @@ def index():
             return jsonify({"error_code": 40000, "message": "Warning: Image parameter not POSTed!"}), 400
         image = request.files.get("image")
         app.logger.debug(f"Uploaded: {image}")
+        if image.filename == "":
+            app.logger.warning("No image has been selected!")
+            return jsonify({"error_code": 41500, "message": "Warning: No image has been selected!"}), 415
         if not allowed_file(image.filename):
             app.logger.warning("Unauthorized extensions!")
-            return jsonify({"error_code": 41500, "message": "Warning: Unauthorized extensions!"}), 415
+            return jsonify({"error_code": 41501, "message": "Warning: Unauthorized extensions!"}), 415
 
         img = np.frombuffer(image.read(), dtype=np.uint8)
         img = cv2.imdecode(img, 1)

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import time
 import cv2
 import numpy as np
 import opencensus.trace.tracer
-from flask import Flask, flash, render_template, request, redirect, make_response
+from flask import Flask, flash, render_template, request, redirect, make_response, jsonify
 from flask_debugtoolbar import DebugToolbarExtension
 from opencensus.ext.stackdriver import trace_exporter as stackdriver_exporter
 
@@ -60,10 +60,10 @@ def allowed_file(filename):
     return "." in filename and filename.rsplit(".", 1)[1].lower() in ALLOWED_EXTENSIONS
 
 
-def redirect_with_flash(url, message, category):
-    app.logger.debug(message)
-    flash(message, category)
-    return redirect(url)
+# def redirect_with_flash(url, message, category):
+#     app.logger.debug(message)
+#     flash(message, category)
+#     return redirect(url)
 
 
 @app.route("/", methods=["GET", "POST"])
@@ -76,13 +76,19 @@ def index():
         start = time.time()
 
         if "image" not in request.files:
-            return redirect_with_flash(request.url, "Warning: Image parameter not POSTed!", "is-warning")
+            # return redirect_with_flash(request.url, "Warning: Image parameter not POSTed!", "is-warning")
+            app.logger.warning("Image parameter not POSTed!")
+            return jsonify({"code": 1, "message": "Warning: Image parameter not POSTed!"}), 400
         image = request.files.get("image")
         app.logger.debug(f"Uploaded: {image}")
         if image.filename == "":
-            return redirect_with_flash(request.url, "Warning: No image has been selected!", "is-warning")
+            # return redirect_with_flash(request.url, "Warning: No image has been selected!", "is-warning")
+            app.logger.warning("No image has been selected!")
+            return jsonify({"code": 2, "message": "Warning: No image has been selected!"}), 400
         if not allowed_file(image.filename):
-            return redirect_with_flash(request.url, "Warning: Unauthorized extensions!", "is-warning")
+            # return redirect_with_flash(request.url, "Warning: Unauthorized extensions!", "is-warning")
+            app.logger.warning("No image has been selected!")
+            return jsonify({"code": 3, "message": "Warning: Unauthorized extensions!"}), 400
 
         img = np.frombuffer(image.read(), dtype=np.uint8)
         img = cv2.imdecode(img, 1)

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -67,19 +67,15 @@ function selectPhoto() {
           trace(error);
           this.closePreview();
           this.stopLoading();
-
-          const errorStatus = [400, 415];
-          if (!errorStatus.includes(error.response.status)) {
-            this.createAlert();
-          } else {
-            const reader = new FileReader();
-            reader.readAsText(error.response.data);
-            reader.onload = () => {
-              trace(reader.result);
+          const reader = new FileReader();
+          reader.readAsText(error.response.data);
+          reader.onload = () => {
+            let type = "danger";
+            let message =
+              "すこし<ruby>時間<rt>じかん</rt></ruby>がたってから、また<ruby>試<rt>ため</rt></ruby>してみてね";
+            try {
               const json = JSON.parse(reader.result);
-              let type = "danger";
-              let message =
-                "すこし<ruby>時間<rt>じかん</rt></ruby>がたってから、また<ruby>試<rt>ため</rt></ruby>してみてね";
+              trace(JSON.stringify(json));
               switch (json.error_code) {
                 case 40000:
                   type = "danger";
@@ -100,9 +96,11 @@ function selectPhoto() {
                     "<ruby>違<rt>ちが</rt></ruby>う<ruby>画像<rt>がぞう</rt></ruby>でお<ruby>試<rt>ため</rt></ruby>しください";
                   break;
               }
-              this.createAlert(type, message);
-            };
-          }
+            } catch(error) {
+              trace(error);
+            }
+            this.createAlert(type, message);
+          };
         });
     },
     createAlert(

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -81,19 +81,13 @@ function selectPhoto() {
               let message =
                 "すこし<ruby>時間<rt>じかん</rt></ruby>がたってから、また<ruby>試<rt>ため</rt></ruby>してみてね";
               switch (json.error_code) {
-                case 1:
+                case 40000:
                   type = "danger";
                   message =
                     "イメージパラメータがありません<br />" +
                     "お<ruby>問<rt>と</rt></ruby>い<ruby>合<rt>あ</rt></ruby>わせください";
                   break;
-                case 2:
-                  type = "warning";
-                  message =
-                    "<ruby>画像<rt>がぞう</rt></ruby>が<ruby>選<rt>えら</rt></ruby>ばれていません<br />" +
-                    "もう<ruby>一度<rt>いちど</rt></ruby>はじめからやりなおしてください";
-                  break;
-                case 3:
+                case 41500:
                   type = "warning";
                   message =
                     "ぬりえにできない<ruby>種類<rt>しゅるい</rt></ruby>の<ruby>画像<rt>がぞう</rt></ruby>です<br />" +

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -90,6 +90,12 @@ function selectPhoto() {
                     "お<ruby>問<rt>と</rt></ruby>い<ruby>合<rt>あ</rt></ruby>わせください";
                   break;
                 case 41500:
+                    type = "warning";
+                    message =
+                      "<ruby>画像<rt>がぞう</rt></ruby>が<ruby>選<rt>えら</rt></ruby>ばれていません<br />" +
+                      "もう<ruby>一度<rt>いちど</rt></ruby>はじめからやりなおしてください";
+                    break;
+                case 41501:
                   type = "warning";
                   message =
                     "ぬりえにできない<ruby>種類<rt>しゅるい</rt></ruby>の<ruby>画像<rt>がぞう</rt></ruby>です<br />" +

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -67,35 +67,53 @@ function selectPhoto() {
           trace(error);
           this.closePreview();
           this.stopLoading();
-          const reader = new FileReader();
-          reader.readAsText(error.response.data);
-          reader.onload = () => {
-            trace(reader.result);
-            const json = JSON.parse(reader.result);
-            let alertType, message;
-            switch (json.code) {
-              case 1:
-                alertType = "error";
-                message = "イメージパラメータがありません";
-              case 2:
-                alertType = "warning";
-                message =
-                  "<ruby>画像<rt>がぞう</rt></ruby>が<ruby>選<rt>えら</rt></ruby>ばれていません";
-              case 3:
-                alertType = "warning";
-                message =
-                  "ぬりえにできない<ruby>画像<rt>がぞう</rt></ruby>の<ruby>種類<rt>しゅるい</rt></ruby>です";
-            }
-            Bulma.create("alert", {
-              type: alertType,
-              title: "しっぱい！",
-              body:
-                message +
-                "<br />すこし<ruby>時間<rt>じかん</rt></ruby>がたってから、また<ruby>試<rt>ため</rt></ruby>してみてね",
-              confirm: "わかりました",
-            });
-          };
+
+          if (error.response.status !== 400) {
+            this.createAlert();
+          } else {
+            const reader = new FileReader();
+            reader.readAsText(error.response.data);
+            reader.onload = () => {
+              trace(reader.result);
+              const json = JSON.parse(reader.result);
+              let type = "danger";
+              let message = "";
+                "すこし<ruby>時間<rt>じかん</rt></ruby>がたってから、また<ruby>試<rt>ため</rt></ruby>してみてね";
+              switch (json.code) {
+                case 1:
+                  type = "danger";
+                  message =
+                    "イメージパラメータがありません<br />" +
+                    "お<ruby>問<rt>と</rt></ruby>い<ruby>合<rt>あ</rt></ruby>わせください";
+                  break;
+                case 2:
+                  type = "warning";
+                  message =
+                    "<ruby>画像<rt>がぞう</rt></ruby>が<ruby>選<rt>えら</rt></ruby>ばれていません<br />" +
+                    "もう<ruby>一度<rt>いちど</rt></ruby>はじめからやりなおしてください";
+                  break;
+                case 3:
+                  type = "warning";
+                  message =
+                    "ぬりえにできない<ruby>種類<rt>しゅるい</rt></ruby>の<ruby>画像<rt>がぞう</rt></ruby>です<br />" +
+                    "<ruby>違<rt>ちが</rt></ruby>う<ruby>画像<rt>がぞう</rt></ruby>でお<ruby>試<rt>ため</rt></ruby>しください";
+                  break;
+              }
+              this.createAlert(type, message);
+            };
+          }
         });
+    },
+    createAlert(
+      type = "danger",
+      message = "すこし<ruby>時間<rt>じかん</rt></ruby>がたってから、また<ruby>試<rt>ため</rt></ruby>してみてね"
+    ) {
+      Bulma.create("alert", {
+        type: type,
+        title: "しっぱい！",
+        body: message,
+        confirm: "わかりました",
+      });
     },
   };
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -68,7 +68,8 @@ function selectPhoto() {
           this.closePreview();
           this.stopLoading();
 
-          if (error.response.status !== 400) {
+          const errorStatus = [400, 415];
+          if (!errorStatus.includes(error.response.status)) {
             this.createAlert();
           } else {
             const reader = new FileReader();
@@ -77,9 +78,9 @@ function selectPhoto() {
               trace(reader.result);
               const json = JSON.parse(reader.result);
               let type = "danger";
-              let message = "";
+              let message =
                 "すこし<ruby>時間<rt>じかん</rt></ruby>がたってから、また<ruby>試<rt>ため</rt></ruby>してみてね";
-              switch (json.code) {
+              switch (json.error_code) {
                 case 1:
                   type = "danger";
                   message =

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -44,12 +44,10 @@ function selectPhoto() {
       trace("selectPhoto.closePreview()");
       modalPreview.close();
     },
-    post(dummy_post = false) {
+    post() {
       trace("selectPhoto.post()");
       const params = new FormData();
-      if (!dummy_post) {
-        params.append("image", fileInput.files[0]);
-      }
+      params.append("image", fileInput.files[0]);
       trace(params);
       axios
         .post("/", params, {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -44,10 +44,12 @@ function selectPhoto() {
       trace("selectPhoto.closePreview()");
       modalPreview.close();
     },
-    post() {
+    post(dummy_post = false) {
       trace("selectPhoto.post()");
       const params = new FormData();
-      params.append("image", fileInput.files[0]);
+      if (!dummy_post) {
+        params.append("image", fileInput.files[0]);
+      }
       trace(params);
       axios
         .post("/", params, {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -88,11 +88,11 @@ function selectPhoto() {
                     "お<ruby>問<rt>と</rt></ruby>い<ruby>合<rt>あ</rt></ruby>わせください";
                   break;
                 case 41500:
-                    type = "warning";
-                    message =
-                      "<ruby>画像<rt>がぞう</rt></ruby>が<ruby>選<rt>えら</rt></ruby>ばれていません<br />" +
-                      "もう<ruby>一度<rt>いちど</rt></ruby>はじめからやりなおしてください";
-                    break;
+                  type = "warning";
+                  message =
+                    "<ruby>画像<rt>がぞう</rt></ruby>が<ruby>選<rt>えら</rt></ruby>ばれていません<br />" +
+                    "もう<ruby>一度<rt>いちど</rt></ruby>はじめからやりなおしてください";
+                  break;
                 case 41501:
                   type = "warning";
                   message =

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -67,13 +67,34 @@ function selectPhoto() {
           trace(error);
           this.closePreview();
           this.stopLoading();
-          Bulma.create("alert", {
-            type: "danger",
-            title: "しっぱい！",
-            body:
-              "すこし<ruby>時間<rt>じかん</rt></ruby>がたってから、また<ruby>試<rt>ため</rt></ruby>してみてね。",
-            confirm: "わかりました",
-          });
+          const reader = new FileReader();
+          reader.readAsText(error.response.data);
+          reader.onload = () => {
+            trace(reader.result);
+            const json = JSON.parse(reader.result);
+            let alertType, message;
+            switch (json.code) {
+              case 1:
+                alertType = "error";
+                message = "イメージパラメータがありません";
+              case 2:
+                alertType = "warning";
+                message =
+                  "<ruby>画像<rt>がぞう</rt></ruby>が<ruby>選<rt>えら</rt></ruby>ばれていません";
+              case 3:
+                alertType = "warning";
+                message =
+                  "ぬりえにできない<ruby>画像<rt>がぞう</rt></ruby>の<ruby>種類<rt>しゅるい</rt></ruby>です";
+            }
+            Bulma.create("alert", {
+              type: alertType,
+              title: "しっぱい！",
+              body:
+                message +
+                "<br />すこし<ruby>時間<rt>じかん</rt></ruby>がたってから、また<ruby>試<rt>ため</rt></ruby>してみてね",
+              confirm: "わかりました",
+            });
+          };
         });
     },
   };

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,18 +18,6 @@
     <p class="browserupgrade">IE9未満用のメッセージ</p>
     <![endif]-->
 
-    <!-- Flash Message -->
-    {% with messages = get_flashed_messages(with_categories=true) %}
-      {% if messages %}
-        {% for category, message in messages %}
-          <div class="notification {{ category }}">
-            <button @click="$el.innerHTML=''" class="delete"></button>
-            {{ message }}
-          </div>
-        {% endfor %}
-      {% endif %}
-    {% endwith %}
-
     {% block content %}
       <!-- Contents Here! -->
     {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -69,7 +69,7 @@
           <input
             class="file-input"
             type="file"
-            accept="image/*"
+            accept="image/{{ allowed_extensions }}"
             name="image"
             id="file-input"
             x-on:change="preview()"

--- a/templates/index.html
+++ b/templates/index.html
@@ -98,6 +98,7 @@
           </section>
           <footer class="modal-card-foot">
             <button id="cancel" class="button is-medium is-outline" @click="closePreview()">やめる</button>
+            <button id="dummy" class="button" @click="post(dummy_post = true)">ダミーポスト</button>
             <button id="submit" class="button is-large is-primary" @click="post()">これでぬりえをつくる</button>
           </footer>
         </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -98,7 +98,6 @@
           </section>
           <footer class="modal-card-foot">
             <button id="cancel" class="button is-medium is-outline" @click="closePreview()">やめる</button>
-            <button id="dummy" class="button" @click="post(dummy_post = true)">ダミーポスト</button>
             <button id="submit" class="button is-large is-primary" @click="post()">これでぬりえをつくる</button>
           </footer>
         </div>


### PR DESCRIPTION
## Describe the PR

To close #27.

## Screenshots

![error_request_3](https://user-images.githubusercontent.com/40506652/79945773-868dc980-84a9-11ea-80b2-2735ab1e8bf1.gif)
↑ 確認のため、ダミーのポストボタンを使ったimageが添付されていない場合と、gif画像をポストした場合

### error処理されるリクエストの確認

クライアント側
<img width="838" alt="スクリーンショット 2020-04-22 14 42 54" src="https://user-images.githubusercontent.com/40506652/79945846-b1781d80-84a9-11ea-954c-171886877cdc.png">

サーバー側
<img width="1135" alt="スクリーンショット 2020-04-22 14 39 15" src="https://user-images.githubusercontent.com/40506652/79945839-ade49680-84a9-11ea-9e0a-3d125095ebdb.png">


## Detail of the change

- Flaskでのerrorレスポンスを変更
- レスポンスによって、エラーアラートのメッセージを変更するように変更

## Anticipated impacts

Flaskのフラッシュメッセージ機能自体を置き換える形で、
アップロード後、エラー時に表示するアラートに統合しました

## To reproduce

`$ python main.py`

## Additional context

特になし