### PR TITLE
Handle Errors

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -9,6 +9,15 @@ handlers:
 - url: /manifest\.json
   static_files: static/manifest.json
   upload: static/manifest\.json
+- url: /apple-touch-icon\.png
+  static_files: static/apple-touch-icon.png
+  upload: static/apple-touch-icon\.png
+- url: /android-chrome-192x192\.png
+  static_files: static/android-chrome-192x192.png
+  upload: static/android-chrome-192x192\.png
+- url: /android-chrome-512x512\.png
+  static_files: static/android-chrome-512x512.png
+  upload: static/android-chrome-512x512\.png
 - url: /.*
   secure: always
   redirect_http_response_code: 301

--- a/app.yaml
+++ b/app.yaml
@@ -22,9 +22,9 @@ handlers:
   secure: always
   redirect_http_response_code: 301
   script: auto
-  error_handlers:
-    - file: error_handlers/default_error.html
-    - error_code: over_quota
-      file: error_handlers/over_quota.html
-    - error_code: timeout
-      file: error_handlers/timeout.html
+error_handlers:
+  - file: error_handlers/default_error.html
+  - error_code: over_quota
+    file: error_handlers/over_quota.html
+  - error_code: timeout
+    file: error_handlers/timeout.html

--- a/app.yaml
+++ b/app.yaml
@@ -22,3 +22,9 @@ handlers:
   secure: always
   redirect_http_response_code: 301
   script: auto
+  error_handlers:
+    - file: error_handlers/default_error.html
+    - error_code: over_quota
+      file: error_handlers/over_quota.html
+    - error_code: timeout
+      file: error_handlers/timeout.html

--- a/error_handlers/default_error.html
+++ b/error_handlers/default_error.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ぬりカメ - はっきんぐパパ</title>
+    <link
+      rel="stylesheet"
+      href="http://fonts.googleapis.com/earlyaccess/notosansjp.css"
+    />
+    <link
+      href="https://fonts.googleapis.com/css?family=Chango"
+      rel="stylesheet"
+    />
+    <style>
+      * {
+        -webkit-box-sizing: border-box;
+        box-sizing: border-box;
+      }
+      body {
+        background: #fefef1;
+        background-color: #fefef1;
+        padding: 0;
+        margin: 0;
+      }
+      #error {
+        position: relative;
+        height: 96vh;
+      }
+      #error .error {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+        transform: translate(-50%, -50%);
+      }
+      .error {
+        max-width: 640px;
+        width: 100%;
+        line-height: 1.4;
+      }
+      .error > div:first-child {
+        padding-left: 200px;
+        padding-top: 12px;
+        height: 170px;
+        margin-bottom: 20px;
+      }
+      .error .error-500 {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 170px;
+        height: 170px;
+        background: #e01818;
+        border-radius: 7px;
+        -webkit-box-shadow: 0px 0px 0px 10px #e01818 inset,
+          0px 0px 0px 20px #fff inset;
+        box-shadow: 0px 0px 0px 10px #e01818 inset, 0px 0px 0px 20px #fff inset;
+      }
+      .error .error-500 h1 {
+        font-family: "Chango", cursive;
+        color: #fff;
+        font-size: 118px;
+        margin: 0px;
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+        transform: translate(-50%, -50%);
+        display: inline-block;
+        height: 60px;
+        line-height: 60px;
+      }
+      .error h2 {
+        font-family: "Chango", cursive;
+        font-size: 48px;
+        color: #222;
+        font-weight: 400;
+        text-transform: uppercase;
+        margin: 0px;
+        line-height: 1.1;
+      }
+      .error p {
+        font-family: "Noto Sans JP", sans-serif;
+        font-size: 16px;
+        font-weight: 400;
+        color: #222;
+        margin-top: 5px;
+      }
+      .error a {
+        font-family: "Noto Sans JP", sans-serif;
+        color: #e01818;
+        font-weight: 400;
+        text-decoration: none;
+      }
+      .footer {
+        height: 3vh;
+      }
+      .footer > p {
+        width: 450px;
+        margin: auto;
+      }
+      @media only screen and (max-width: 480px) {
+        .error {
+          padding-left: 15px;
+          padding-right: 15px;
+        }
+        .error > div:first-child {
+          padding: 0px;
+          height: auto;
+        }
+        .error .error-500 {
+          position: relative;
+          margin-bottom: 15px;
+        }
+        .error h2 {
+          font-size: 42px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="error">
+      <div class="error">
+        <div>
+          <div class="error-500">
+            <h1>!</h1>
+          </div>
+          <h2>しっぱい！</h2>
+          <h3>500: Internal Server Error</h3>
+          <h4>Something Wrong!!</h4>
+        </div>
+        <p>
+          すこし<ruby>時間<rt>じかん</rt></ruby
+          >がたってから、また<ruby>試<rt>ため</rt></ruby
+          >してみてね。&rArr;
+          <a href="/">トップページにもどる。</a>
+        </p>
+      </div>
+    </div>
+    <footer class="footer">
+      <p>
+        &copy; 2020
+        <a href="https://hacking-papa.com/" target="_blank">はっきんぐパパ</a>
+        おーるらいつりざーぶど
+      </p>
+    </footer>
+    <!-- Google Analytics -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=UA-133451341-1"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+      gtag("config", "UA-133451341-1");
+    </script>
+  </body>
+</html>

--- a/error_handlers/over_quota.html
+++ b/error_handlers/over_quota.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ぬりカメ - はっきんぐパパ</title>
+    <link
+      rel="stylesheet"
+      href="http://fonts.googleapis.com/earlyaccess/notosansjp.css"
+    />
+    <link
+      href="https://fonts.googleapis.com/css?family=Chango"
+      rel="stylesheet"
+    />
+    <style>
+      * {
+        -webkit-box-sizing: border-box;
+        box-sizing: border-box;
+      }
+      body {
+        background: #fefef1;
+        background-color: #fefef1;
+        padding: 0;
+        margin: 0;
+      }
+      #error {
+        position: relative;
+        height: 96vh;
+      }
+      #error .error {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+        transform: translate(-50%, -50%);
+      }
+      .error {
+        max-width: 640px;
+        width: 100%;
+        line-height: 1.4;
+      }
+      .error > div:first-child {
+        padding-left: 200px;
+        padding-top: 12px;
+        height: 170px;
+        margin-bottom: 20px;
+      }
+      .error .error-500 {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 170px;
+        height: 170px;
+        background: #e01818;
+        border-radius: 7px;
+        -webkit-box-shadow: 0px 0px 0px 10px #e01818 inset,
+          0px 0px 0px 20px #fff inset;
+        box-shadow: 0px 0px 0px 10px #e01818 inset, 0px 0px 0px 20px #fff inset;
+      }
+      .error .error-500 h1 {
+        font-family: "Chango", cursive;
+        color: #fff;
+        font-size: 118px;
+        margin: 0px;
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+        transform: translate(-50%, -50%);
+        display: inline-block;
+        height: 60px;
+        line-height: 60px;
+      }
+      .error h2 {
+        font-family: "Chango", cursive;
+        font-size: 48px;
+        color: #222;
+        font-weight: 400;
+        text-transform: uppercase;
+        margin: 0px;
+        line-height: 1.1;
+      }
+      .error p {
+        font-family: "Noto Sans JP", sans-serif;
+        font-size: 16px;
+        font-weight: 400;
+        color: #222;
+        margin-top: 5px;
+      }
+      .error a {
+        font-family: "Noto Sans JP", sans-serif;
+        color: #e01818;
+        font-weight: 400;
+        text-decoration: none;
+      }
+      .footer {
+        height: 3vh;
+      }
+      .footer > p {
+        width: 450px;
+        margin: auto;
+      }
+      @media only screen and (max-width: 480px) {
+        .error {
+          padding-left: 15px;
+          padding-right: 15px;
+        }
+        .error > div:first-child {
+          padding: 0px;
+          height: auto;
+        }
+        .error .error-500 {
+          position: relative;
+          margin-bottom: 15px;
+        }
+        .error h2 {
+          font-size: 42px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="error">
+      <div class="error">
+        <div>
+          <div class="error-500">
+            <h1>!</h1>
+          </div>
+          <h2>しっぱい！</h2>
+          <h3>500: Internal Server Error</h3>
+          <h4>Over Quota!!</h4>
+        </div>
+        <p>
+          すこし<ruby>時間<rt>じかん</rt></ruby
+          >がたってから、また<ruby>試<rt>ため</rt></ruby
+          >してみてね。&rArr;
+          <a href="/">トップページにもどる。</a>
+        </p>
+      </div>
+    </div>
+    <footer class="footer">
+      <p>
+        &copy; 2020
+        <a href="https://hacking-papa.com/" target="_blank">はっきんぐパパ</a>
+        おーるらいつりざーぶど
+      </p>
+    </footer>
+    <!-- Google Analytics -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=UA-133451341-1"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+      gtag("config", "UA-133451341-1");
+    </script>
+  </body>
+</html>

--- a/error_handlers/timeout.html
+++ b/error_handlers/timeout.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ぬりカメ - はっきんぐパパ</title>
+    <link
+      rel="stylesheet"
+      href="http://fonts.googleapis.com/earlyaccess/notosansjp.css"
+    />
+    <link
+      href="https://fonts.googleapis.com/css?family=Chango"
+      rel="stylesheet"
+    />
+    <style>
+      * {
+        -webkit-box-sizing: border-box;
+        box-sizing: border-box;
+      }
+      body {
+        background: #fefef1;
+        background-color: #fefef1;
+        padding: 0;
+        margin: 0;
+      }
+      #error {
+        position: relative;
+        height: 96vh;
+      }
+      #error .error {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+        transform: translate(-50%, -50%);
+      }
+      .error {
+        max-width: 640px;
+        width: 100%;
+        line-height: 1.4;
+      }
+      .error > div:first-child {
+        padding-left: 200px;
+        padding-top: 12px;
+        height: 170px;
+        margin-bottom: 20px;
+      }
+      .error .error-500 {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 170px;
+        height: 170px;
+        background: #e01818;
+        border-radius: 7px;
+        -webkit-box-shadow: 0px 0px 0px 10px #e01818 inset,
+          0px 0px 0px 20px #fff inset;
+        box-shadow: 0px 0px 0px 10px #e01818 inset, 0px 0px 0px 20px #fff inset;
+      }
+      .error .error-500 h1 {
+        font-family: "Chango", cursive;
+        color: #fff;
+        font-size: 118px;
+        margin: 0px;
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+        transform: translate(-50%, -50%);
+        display: inline-block;
+        height: 60px;
+        line-height: 60px;
+      }
+      .error h2 {
+        font-family: "Chango", cursive;
+        font-size: 48px;
+        color: #222;
+        font-weight: 400;
+        text-transform: uppercase;
+        margin: 0px;
+        line-height: 1.1;
+      }
+      .error p {
+        font-family: "Noto Sans JP", sans-serif;
+        font-size: 16px;
+        font-weight: 400;
+        color: #222;
+        margin-top: 5px;
+      }
+      .error a {
+        font-family: "Noto Sans JP", sans-serif;
+        color: #e01818;
+        font-weight: 400;
+        text-decoration: none;
+      }
+      .footer {
+        height: 3vh;
+      }
+      .footer > p {
+        width: 450px;
+        margin: auto;
+      }
+      @media only screen and (max-width: 480px) {
+        .error {
+          padding-left: 15px;
+          padding-right: 15px;
+        }
+        .error > div:first-child {
+          padding: 0px;
+          height: auto;
+        }
+        .error .error-500 {
+          position: relative;
+          margin-bottom: 15px;
+        }
+        .error h2 {
+          font-size: 42px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="error">
+      <div class="error">
+        <div>
+          <div class="error-500">
+            <h1>!</h1>
+          </div>
+          <h2>しっぱい！</h2>
+          <h3>500: Internal Server Error</h3>
+          <h4>Timeout!!</h4>
+        </div>
+        <p>
+          すこし<ruby>時間<rt>じかん</rt></ruby
+          >がたってから、また<ruby>試<rt>ため</rt></ruby
+          >してみてね。&rArr;
+          <a href="/">トップページにもどる。</a>
+        </p>
+      </div>
+    </div>
+    <footer class="footer">
+      <p>
+        &copy; 2020
+        <a href="https://hacking-papa.com/" target="_blank">はっきんぐパパ</a>
+        おーるらいつりざーぶど
+      </p>
+    </footer>
+    <!-- Google Analytics -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=UA-133451341-1"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+      gtag("config", "UA-133451341-1");
+    </script>
+  </body>
+</html>

--- a/main.py
+++ b/main.py
@@ -78,6 +78,21 @@ def manifest():
     return send_from_directory("static", "manifest.json")
 
 
+@app.route("/apple-touch-icon.png")
+def apple_touch_icon():
+    return send_from_directory("static", "apple-touch-icon.png")
+
+
+@app.route("/android-chrome-192x192.png")
+def android_chrome_192x192():
+    return send_from_directory("static", "android-chrome-192x192.png")
+
+
+@app.route("/android-chrome-512x512.png")
+def android_chrome_512x512():
+    return send_from_directory("static", "android-chrome-512x512.png")
+
+
 @app.route("/", methods=["GET"])
 def index():
     app.logger.debug("GET /index")

--- a/main.py
+++ b/main.py
@@ -107,15 +107,15 @@ def result():
 
     if "image" not in request.files:
         app.logger.warning("Image parameter not POSTed!")
-        return redirect_with_flash("/", "Warning: Image parameter not POSTed!", "is-warning")
+        return redirect_with_flash("/", "Warning: イメージパラメータがありません！", "is-warning")
     image = request.files.get("image")
     app.logger.debug(f"Uploaded: {image}")
     if image.filename == "":
         app.logger.warning("No image has been selected!")
-        return redirect_with_flash("/", "Warning: No image has been selected!", "is-warning")
+        return redirect_with_flash("/", "Warning: 画像が選ばれていません。もう一度はじめからやりなおしてください。", "is-warning")
     if not allowed_file(image.filename):
         app.logger.warning("Unauthorized extensions!")
-        return redirect_with_flash("/", "Warning: Unauthorized extensions!", "is-warning")
+        return redirect_with_flash("/", "Warning: ぬりえにできない種類の画像です。違う画像で試しください。", "is-warning")
 
     img = np.frombuffer(image.read(), dtype=np.uint8)
     img = cv2.imdecode(img, 1)

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -7,16 +7,16 @@
   "theme_color": "#fefef1",
   "icons": [
     {
-      "src": "static/apple-touch-icon.png",
+      "src": "/apple-touch-icon.png",
       "type": "image/png"
     },
     {
-      "src": "static/android-chrome-192x192.png",
+      "src": "/android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "static/android-chrome-512x512.png",
+      "src": "/android-chrome-512x512.png",
       "sizes": "512x512"
     }
   ]

--- a/templates/base.html
+++ b/templates/base.html
@@ -48,7 +48,9 @@
       property="og:image"
       content="{{ request.url_root }}static/img/OGP.png"
     />
-    <meta content="TODO: 説明文" name="description" />
+    <meta
+      content="外出できなくて遊ぶものがない！家遊びに飽きた！という子どもたちのために。撮ったものをなんでもぬりえにしてくれる魔法のカメラ「ぬりカメ」をWEBばんで公開します。ぜひ、ご家庭でぬりえを作って遊んでください。"
+      name="description"/>
     <meta
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
       name="viewport"

--- a/templates/index.html
+++ b/templates/index.html
@@ -58,7 +58,7 @@
             <input
               class="file-input"
               type="file"
-              accept="image/{{ allowed_extensions | join(',') }},.gif"
+              accept="image/{{ allowed_extensions | join(',') }}"
               name="image"
               id="file-input"
               x-on:change="openPreview()"


### PR DESCRIPTION
## Describe the PR

To close #37 and #39 

## Screenshots

![Screen Shot 2020-04-26 at 4 50 06](https://user-images.githubusercontent.com/32637762/80289457-7c095380-8779-11ea-86ee-28a6f6b8e635.png)

## Detail of the change

- `app.yaml`
  - `static_files` for `apple-touch-icon.png` , `android-chrome-192x192.png` and `android-chrome-512x512.png`
  - `error_handlers` for `default_error.html` , `over_quota.html` and `timeout.html`
- `main.py`
  - `@app.route` for `apple-touch-icon.png` , `android-chrome-192x192.png` and `android-chrome-512x512.png`

```python
@app.route("/apple-touch-icon.png")
def apple_touch_icon():
    return send_from_directory("static", "apple-touch-icon.png")


@app.route("/android-chrome-192x192.png")
def android_chrome_192x192():
    return send_from_directory("static", "android-chrome-192x192.png")


@app.route("/android-chrome-512x512.png")
def android_chrome_512x512():
    return send_from_directory("static", "android-chrome-512x512.png")
```

## Anticipated impacts

None.

## To reproduce

Pull and `python main.py` .

## Additional context

None.